### PR TITLE
rw - earthquakes retrieval

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/EarthquakesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/EarthquakesController.java
@@ -1,0 +1,60 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.services.EarthquakeQueryService;
+import edu.ucsb.cs156.example.documents.EarthquakeFeature;
+import edu.ucsb.cs156.example.collections.EarthquakesCollection;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+
+@Api(description="Earthquake info from USGS")
+@Slf4j
+@RestController
+@RequestMapping("/api/earthquakes")
+public class EarthquakesController {
+
+    @Autowired
+    EarthquakeQueryService earthquakeQueryService;
+
+    @Autowired
+    EarthquakesCollection earthquakesCollection;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @ApiOperation(value = "Get earthquakes a certain distance from UCSB's Storke Tower that are at or above a certain magnitude and add them to the database collection", notes = "JSON return format documented here: https://earthquake.usgs.gov/earthquakes/feed/v1.0/geojson.php")
+    @PostMapping("/retrieve")
+    public ResponseEntity<Iterable<EarthquakeFeature>> retrieveEarthquakes(
+            @ApiParam("distance in km from Storke Tower, e.g. 100") @RequestParam String distanceKm,
+            @ApiParam("minimum magnitude, e.g. 2.5") @RequestParam String minMagnitude
+    ) throws JsonProcessingException {
+        log.info("retrieveEarthquakes: distanceKm={} minMagnitude={}", distanceKm, minMagnitude);
+
+        // query USGS API to get earthquakes
+        Iterable<EarthquakeFeature> results = earthquakeQueryService.retrieveEarthquakes(distanceKm, minMagnitude);
+
+        // save results to database
+        Iterable<EarthquakeFeature> savedResults = earthquakesCollection.saveAll(results);
+
+         return ResponseEntity.ok().body(savedResults);
+    }
+
+    // not yet implemented, this was
+//    @PreAuthorize("hasRole('ROLE_USER')")
+//    @ApiOperation(value = "Get earthquakes a certain distance from UCSB's Storke Tower that are at or above a certain magnitude and add them to the database collection", notes = "JSON return format documented here: https://earthquake.usgs.gov/earthquakes/feed/v1.0/geojson.php")
+//    @GetMapping("/all")
+//    public ResponseEntity<String> getEarthquakes() throws JsonProcessingException {
+//        return ResponseEntity.ok().body(result);
+//    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/services/EarthquakeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/EarthquakeQueryService.java
@@ -35,7 +35,7 @@ public class EarthquakeQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&minmagnitude={minMag}&maxradiuskm={distance}&latitude={latitude}&longitude={longitude}";
+    public static final String ENDPOINT = "https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&minmagnitude={minMagnitude}&maxradiuskm={distanceKm}&latitude={latitude}&longitude={longitude}";
 
     public Iterable<EarthquakeFeature> retrieveEarthquakes(String distanceKm, String minMagnitude) throws HttpClientErrorException, JsonProcessingException {
         log.info("distanceKm={}, minMagnitude={}", distanceKm, minMagnitude);

--- a/src/main/java/edu/ucsb/cs156/example/services/EarthquakeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/EarthquakeQueryService.java
@@ -1,15 +1,27 @@
 package edu.ucsb.cs156.example.services;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.extern.slf4j.Slf4j;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.springframework.web.client.RestTemplate;
+
+import edu.ucsb.cs156.example.documents.EarthquakeFeatureListing;
+import edu.ucsb.cs156.example.documents.EarthquakeFeature;
+
 import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.http.*;
+
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
 import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 
 @Slf4j
 @Service
@@ -25,22 +37,27 @@ public class EarthquakeQueryService {
 
     public static final String ENDPOINT = "https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&minmagnitude={minMag}&maxradiuskm={distance}&latitude={latitude}&longitude={longitude}";
 
-    public String getJSON(String distance, String minMag) throws HttpClientErrorException {
-        log.info("distance={}, minMag={}", distance, minMag);
+    public Iterable<EarthquakeFeature> retrieveEarthquakes(String distanceKm, String minMagnitude) throws HttpClientErrorException, JsonProcessingException {
+        log.info("distanceKm={}, minMagnitude={}", distanceKm, minMagnitude);
         HttpHeaders headers = new HttpHeaders();
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
         headers.setContentType(MediaType.APPLICATION_JSON);
 
         HttpEntity<String> entity = new HttpEntity<>(headers);
 
-        String ucsbLat = "34.4140"; // hard coded params for Storke Tower
-        String ucsbLong = "-119.8489";
-        Map<String, String> uriVariables = Map.of("minMag", minMag, "distance", distance, "latitude", ucsbLat,
+        final String ucsbLat = "34.4140"; // hard coded params for Storke Tower
+        final String ucsbLong = "-119.8489";
+        Map<String, String> uriVariables = Map.of("minMagnitude", minMagnitude, "distanceKm", distanceKm, "latitude", ucsbLat,
                 "longitude", ucsbLong);
 
         ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
                 uriVariables);
-        return re.getBody();
+
+        String jsonResult = re.getBody();
+
+        EarthquakeFeatureListing featureListing = mapper.readValue(jsonResult, EarthquakeFeatureListing.class);
+
+        return featureListing.getFeatures();
     }
 
    

--- a/src/main/java/edu/ucsb/cs156/example/services/EarthquakeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/EarthquakeQueryService.java
@@ -1,0 +1,48 @@
+package edu.ucsb.cs156.example.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+public class EarthquakeQueryService {
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    private final RestTemplate restTemplate;
+
+    public EarthquakeQueryService(RestTemplateBuilder restTemplateBuilder) {
+        restTemplate = restTemplateBuilder.build();
+    }
+
+    public static final String ENDPOINT = "https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&minmagnitude={minMag}&maxradiuskm={distance}&latitude={latitude}&longitude={longitude}";
+
+    public String getJSON(String distance, String minMag) throws HttpClientErrorException {
+        log.info("distance={}, minMag={}", distance, minMag);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        String ucsbLat = "34.4140"; // hard coded params for Storke Tower
+        String ucsbLong = "-119.8489";
+        Map<String, String> uriVariables = Map.of("minMag", minMag, "distance", distance, "latitude", ucsbLat,
+                "longitude", ucsbLong);
+
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
+                uriVariables);
+        return re.getBody();
+    }
+
+   
+
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/EarthquakesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/EarthquakesControllerTests.java
@@ -1,0 +1,145 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.collections.EarthquakesCollection;
+import edu.ucsb.cs156.example.documents.EarthquakeFeature;
+import edu.ucsb.cs156.example.documents.EarthquakeFeatureGeometry;
+import edu.ucsb.cs156.example.documents.EarthquakeFeatureProperties;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.services.EarthquakeQueryService;
+import lombok.With;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+
+@WebMvcTest(value = EarthquakesController.class)
+public class EarthquakesControllerTests extends ControllerTestCase {
+
+  @MockBean
+  EarthquakesCollection earthquakesCollection;
+
+  @MockBean
+  EarthquakeQueryService earthquakeQueryService;
+
+  @MockBean
+  UserRepository userRepository;
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void api_earthquakes_retrieve__admin_logged_in__saves_earthquakes_to_collection() throws Exception {
+
+    String distanceKm = "100";
+    String minMagnitude = "1.5";
+    String url = String.format("/api/earthquakes/retrieve?distanceKm=%s&minMagnitude=%s",distanceKm,minMagnitude);
+
+    // create dummy Earthquake data
+    EarthquakeFeatureProperties props = EarthquakeFeatureProperties.builder()
+            .mag(5.6)
+            .place("testPlace")
+            .time(0x1000000000L)
+            .updated(0x1000000050L)
+            .tz(4)
+            .url("testPropertiesUrl")
+            .detail("testPropertiesDetail")
+            .felt(24)
+            .cdi(2.6)
+            .mmi(5.2)
+            .alert("testPropertiesAlert")
+            .status("testPropertiesStatus")
+            .tsunami(0)
+            .sig(114)
+            .net("testPropertiesNet")
+            .code("testPropertiesCode")
+            .ids("testPropertiesIds")
+            .sources("testPropertiesSources")
+            .types("testPropertiesTypes")
+            .nst(79)
+            .dmin(0.0207)
+            .rms(0.4)
+            .gap(65)
+            .magType("testPropertiesMagType")
+            .type("testPropertiesType")
+            .title("testPropertiesTitle")
+            .build();
+
+    EarthquakeFeatureGeometry geometry = EarthquakeFeatureGeometry.builder()
+            .type("Point")
+            .coordinates(List.of(0.0, 1.0, 2.0))
+            .id("testGeometryId")
+            .build();
+
+    EarthquakeFeature quake1 = EarthquakeFeature.builder()
+            ._id("")
+            .id("testQuakeId1")
+            .type("Feature")
+            .geometry(geometry)
+            .properties(props)
+            .build();
+
+    EarthquakeFeature quake2 = EarthquakeFeature.builder()
+            ._id("")
+            .id("testQuakeId2")
+            .type("Feature")
+            .geometry(geometry)
+            .properties(props)
+            .build();
+
+    List<EarthquakeFeature> quakeList = List.of(quake1, quake2);
+
+    List<String> quakeListAsJSON = new ArrayList<>();
+    for (EarthquakeFeature q : quakeList)
+      quakeListAsJSON.add(mapper.writeValueAsString(q));
+
+    List<EarthquakeFeature> savedQuakes = new ArrayList<>();
+    for (String q : quakeListAsJSON)
+      savedQuakes.add(mapper.readValue(q, EarthquakeFeature.class));
+
+    for (EarthquakeFeature q : savedQuakes)
+      q.set_id(q.get_id() + "_saved");
+
+    String savedQuakesAsJSON = mapper.writeValueAsString(savedQuakes);
+
+    when(earthquakesCollection.saveAll(eq(quakeList))).thenReturn(savedQuakes);
+
+    when(earthquakeQueryService.retrieveEarthquakes(eq(distanceKm), eq(minMagnitude))).thenReturn(quakeList);
+
+    MvcResult response = mockMvc.perform(post(url).with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+
+    verify(earthquakeQueryService, times(1)).retrieveEarthquakes(eq(distanceKm), eq(minMagnitude));
+    verify(earthquakesCollection, times(1)).saveAll(eq(quakeList));
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(mapper.writeValueAsString(savedQuakes), responseString);
+  }
+
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void api_earthquakes_retrieve__non_admin_user_logged_in__returns_403() throws Exception {
+    mockMvc.perform(post("/api/earthquakes/retrieve?distanceKm=10000&minMagnitude=0"))
+            .andExpect(status().is(403));
+  }
+
+  @Test
+  public void api_earthquakes_retrieve__logged_out__returns_403() throws Exception {
+    mockMvc.perform(post("/api/earthquakes/retrieve?distanceKm=10000&minMagnitude=0"))
+            .andExpect(status().is(403));
+  }
+
+}

--- a/src/test/java/edu/ucsb/cs156/example/services/EarthquakeQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/services/EarthquakeQueryServiceTests.java
@@ -1,0 +1,43 @@
+package edu.ucsb.cs156.example.services;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@RestClientTest(EarthquakeQueryService.class)
+public class EarthquakeQueryServiceTests {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private EarthquakeQueryService earthquakeQueryService;
+
+    @Test
+    public void test_getJSON() {
+
+        String distance = "10";
+        String minMag = "1.5";
+        String ucsbLat = "34.4140"; // hard coded params for Storke Tower
+        String ucsbLong = "-119.8489";
+        String expectedURL = EarthquakeQueryService.ENDPOINT.replace("{distance}", distance)
+                .replace("{minMag}", minMag).replace("{latitude}", ucsbLat).replace("{longitude}", ucsbLong);
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = earthquakeQueryService.getJSON(distance, minMag);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/example/services/EarthquakeQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/services/EarthquakeQueryServiceTests.java
@@ -1,10 +1,15 @@
 package edu.ucsb.cs156.example.services;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.example.documents.*;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
@@ -20,24 +25,90 @@ public class EarthquakeQueryServiceTests {
     @Autowired
     private EarthquakeQueryService earthquakeQueryService;
 
-    @Test
-    public void test_getJSON() {
+    @Autowired
+    private ObjectMapper mapper;
 
-        String distance = "10";
-        String minMag = "1.5";
+    @Test
+    public void test_retrieveEarthquakes() throws JsonProcessingException {
+
+        String distanceKm = "10";
+        String minMagnitude = "1.5";
         String ucsbLat = "34.4140"; // hard coded params for Storke Tower
         String ucsbLong = "-119.8489";
-        String expectedURL = EarthquakeQueryService.ENDPOINT.replace("{distance}", distance)
-                .replace("{minMag}", minMag).replace("{latitude}", ucsbLat).replace("{longitude}", ucsbLong);
+        String expectedURL = EarthquakeQueryService.ENDPOINT.replace("{distanceKm}", distanceKm)
+                .replace("{minMagnitude}", minMagnitude).replace("{latitude}", ucsbLat).replace("{longitude}", ucsbLong);
 
-        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+        // create dummy Earthquake data
+        EarthquakeFeatureProperties props = EarthquakeFeatureProperties.builder()
+                .mag(5.6)
+                .place("testPlace")
+                .time(0x1000000000L)
+                .updated(0x1000000050L)
+                .tz(4)
+                .url("testUrl")
+                .detail("testDetail")
+                .felt(24)
+                .cdi(2.6)
+                .mmi(5.2)
+                .alert("testAlert")
+                .status("testStatus")
+                .tsunami(0)
+                .sig(114)
+                .net("testNet")
+                .code("testCode")
+                .ids("testIds")
+                .sources("testSources")
+                .types("testTypes")
+                .nst(79)
+                .dmin(0.0207)
+                .rms(0.4)
+                .gap(65)
+                .magType("testMagType")
+                .type("testType")
+                .title("testTitle")
+                .build();
+
+        EarthquakeFeatureListingMetadata metadata = EarthquakeFeatureListingMetadata.builder()
+                .generated(0xFFFFFFFFFFFFFFFFL)
+                .url("testUrl")
+                .title("testTitle")
+                .api("testApi")
+                .count(4)
+                .status(1)
+                .build();
+
+        EarthquakeFeatureGeometry geometry = EarthquakeFeatureGeometry.builder()
+                .type("testType")
+                .coordinates(List.of(0.0, 1.0, 2.0))
+                .id("testId")
+                .build();
+
+        EarthquakeFeature quake = EarthquakeFeature.builder()
+                ._id("123456789")
+                .id("testId")
+                .type("Feature")
+                .geometry(geometry)
+                .properties(props)
+                .build();
+
+        EarthquakeFeatureListing listing = EarthquakeFeatureListing.builder()
+                .type("FeatureListing")
+                .features(List.of(quake))
+                .metadata(metadata)
+                .build();
+
+
+        String fakeJsonResult = mapper.writeValueAsString(listing);
 
         this.mockRestServiceServer.expect(requestTo(expectedURL))
                 .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
                 .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
                 .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
 
-        String actualResult = earthquakeQueryService.getJSON(distance, minMag);
-        assertEquals(fakeJsonResult, actualResult);
+        Iterable<EarthquakeFeature> actualResult = earthquakeQueryService.retrieveEarthquakes(distanceKm, minMagnitude);
+        String actualResultJSON = mapper.writeValueAsString(actualResult);
+        String expectedResultJSON = mapper.writeValueAsString(listing.getFeatures());
+
+        assertEquals(expectedResultJSON, actualResultJSON);
     }
 }


### PR DESCRIPTION
This pr closes issues #20 and #21. It implement a `/api/earthquakes/retrieve` endpoint:
<img width="1527" alt="image" src="https://user-images.githubusercontent.com/59625987/154779597-105722f3-35f1-45cd-a2ea-0be32c61f913.png">



This endpoint allows an admin to query the USGS for all earthquakes above a certain magnitude within a specified radius of Storke Tower, and then saves the results to the mongoDB database in JSON form:
<img width="795" alt="image" src="https://user-images.githubusercontent.com/59625987/154779550-91b6c0a6-7820-441d-8015-019ff7543893.png">
