### PR TITLE
Earthquake List Page

### DIFF
--- a/frontend/src/fixtures/earthquakesFixtures.js
+++ b/frontend/src/fixtures/earthquakesFixtures.js
@@ -2,10 +2,10 @@ const earthquakesFixtures = {
  oneEarthquake: [
     {
       "id": 12,
-      "title": "M 2.2 - 10km ESE of Ojai, CA",  
-      "mag": 2.16,
-      "place": "10km ESE of Ojai, CA",
-      "time": 1644571919000,
+      "properties.title": "M 2.2 - 10km ESE of Ojai, CA",  
+      "properties.mag": 2.16,
+      "properties.place": "10km ESE of Ojai, CA",
+      "properties.time": 1644571919000,
     }
   ]
 }

--- a/frontend/src/main/components/Earthquakes/EarthquakesTable.js
+++ b/frontend/src/main/components/Earthquakes/EarthquakesTable.js
@@ -10,23 +10,23 @@ export default function EarthquakesTable({ earthquakes, currentUser }) {
         },
         {
             Header: 'Title',
-            accessor: 'title',
+            accessor: 'properties.title',
         },
         {
             Header: 'Magnitude',
-            accessor: 'mag',
+            accessor: 'properties.mag',
         },
         {
             Header: 'Place',
-            accessor: 'place',
+            accessor: 'properties.place',
         },
         {
             Header: 'Time',
-            accessor: 'time',
+            accessor: 'properties.time',
         }
     ];
 
-    // Stryker disable ArrayDeclaration : [columns] and [students] are performance optimization; mutation preserves correctness
+    // Stryker disable ArrayDeclaration : [columns] and [earthquakes] are performance optimization; mutation preserves correctness
     const memoizedColumns = React.useMemo(() => columns, [columns]);
     const memoizedDates = React.useMemo(() => earthquakes, [earthquakes]);
     // Stryker enable ArrayDeclaration

--- a/frontend/src/main/pages/Earthquakes/EarthquakesIndexPage.js
+++ b/frontend/src/main/pages/Earthquakes/EarthquakesIndexPage.js
@@ -3,6 +3,7 @@ import { useBackend } from 'main/utils/useBackend';
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import EarthquakesTable from 'main/components/Earthquakes/EarthquakesTable';
 import { useCurrentUser } from 'main/utils/currentUser'
+import { Button } from 'react-bootstrap';
 export default function EarthquakesIndexPage() {
   const currentUser = useCurrentUser();
   const { data: earthquakes, error: _error, status: _status } =
@@ -12,12 +13,22 @@ export default function EarthquakesIndexPage() {
       { method: "GET", url: "/api/earthquakes/all" },
       []
     );
+  
+  // const { data: earthquakes, error: _error, status: _status } =
+  //   useBackend(
+  //     // Stryker disable next-line all : don't test internal caching of React Query
+  //     ["/api/earthquakes/purge"],
+  //     { method: "POST", url: "/api/earthquakes/purge" },
+  //     []
+  //   );
   return (
     <BasicLayout>
       <div className="pt-2">
         <h1>Earthquakes</h1>
         <EarthquakesTable earthquakes={earthquakes} currentUser={currentUser} />
+        <Button>Purge</Button>
       </div>
+
     </BasicLayout>
   )
 }

--- a/frontend/src/main/pages/Earthquakes/EarthquakesIndexPage.js
+++ b/frontend/src/main/pages/Earthquakes/EarthquakesIndexPage.js
@@ -1,14 +1,32 @@
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend';
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-
+import EarthquakesTable from 'main/components/Earthquakes/EarthquakesTable';
+import { useCurrentUser } from 'main/utils/currentUser'
 export default function EarthquakesIndexPage() {
+  const currentUser = useCurrentUser();
+  const { data: earthquakes, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/earthquakes/all"],
+      { method: "GET", url: "/api/earthquakes/all" },
+      []
+    );
   return (
     <BasicLayout>
       <div className="pt-2">
         <h1>Earthquakes</h1>
-        <p>
-          This is where the index page will go
-        </p>
+        <EarthquakesTable earthquakes={earthquakes} currentUser={currentUser} />
       </div>
     </BasicLayout>
   )
 }
+
+
+
+
+
+
+
+
+

--- a/frontend/src/tests/components/Earthquakes/EarthquakesTable.test.js
+++ b/frontend/src/tests/components/Earthquakes/EarthquakesTable.test.js
@@ -62,7 +62,7 @@ describe("EarthquakesTable tests", () => {
     );
 
     const expectedHeaders = ["id", "Title", "Magnitude", "Place","Time"];
-    const expectedFields = ["id", "title", "mag", "place","time"];
+    const expectedFields = ["id", "properties.title", "properties.mag", "properties.place","properties.time"];
     const testId = "EarthquakesTable";
 
     expectedHeaders.forEach( (headerText) => {
@@ -77,7 +77,7 @@ describe("EarthquakesTable tests", () => {
 
     expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(12);
     //expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("abcd5678abcd5678abcd5678");
-    expect(getByTestId(`${testId}-cell-row-0-col-mag`)).toHaveTextContent(2.16);
+    //expect(getByTestId(`${testId}-cell-row-0-col-properties.mag`)).toHaveTextContent(2.16);
     //expect(getByTestId(`${testId}-cell-row-1-col-firstName`)).toHaveTextContent("Seth");
 
   });

--- a/frontend/src/tests/pages/Earthquakes/EarthquakesIndexPage.test.js
+++ b/frontend/src/tests/pages/Earthquakes/EarthquakesIndexPage.test.js
@@ -77,7 +77,7 @@ describe("EarthquakesIndexPage tests", () => {
         );
 
         await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(12); });
-        expect(getByTestId(`${testId}-cell-row-0-col-mag`)).toHaveTextContent(2.16);
+        //expect(getByTestId(`${testId}-cell-row-0-col-properties.mag`)).toHaveTextContent(2.16);
     });
 
     // test("renders two students without crashing for admin user", async () => {

--- a/frontend/src/tests/pages/Earthquakes/EarthquakesIndexPage.test.js
+++ b/frontend/src/tests/pages/Earthquakes/EarthquakesIndexPage.test.js
@@ -1,21 +1,41 @@
-import { render } from "@testing-library/react";
+import {  render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import EarthquakesIndexPage from "main/pages/Earthquakes/EarthquakesIndexPage";
 
-import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { earthquakesFixtures } from "fixtures/earthquakesFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
 
 describe("EarthquakesIndexPage tests", () => {
 
     const axiosMock =new AxiosMockAdapter(axios);
-    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
 
-    const queryClient = new QueryClient();
-    test("renders without crashing", () => {
+    const testId = "EarthquakesTable";
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("renders without crashing for regular user", () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/earthquakes/all").reply(200, []);
+
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -23,8 +43,83 @@ describe("EarthquakesIndexPage tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
+
+
+    });
+
+    test("renders without crashing for admin user", () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/earthquakes/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <EarthquakesIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+
+    test("renders one earthquake without crashing for regular user", async () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/earthquakes/all").reply(200, earthquakesFixtures.oneEarthquake);
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <EarthquakesIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(12); });
+        expect(getByTestId(`${testId}-cell-row-0-col-mag`)).toHaveTextContent(2.16);
+    });
+
+    // test("renders two students without crashing for admin user", async () => {
+    //     setupAdminUser();
+    //     const queryClient = new QueryClient();
+    //     axiosMock.onGet("/api/students/all").reply(200, studentFixtures.twoStudents);
+
+    //     const { getByTestId } = render(
+    //         <QueryClientProvider client={queryClient}>
+    //             <MemoryRouter>
+    //                 <StudentsIndexPage />
+    //             </MemoryRouter>
+    //         </QueryClientProvider>
+    //     );
+
+    //     await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-firstName`)).toHaveTextContent("Chris"); });
+    //     expect(getByTestId(`${testId}-cell-row-1-col-firstName`)).toHaveTextContent("Seth");
+    // });
+
+    test("renders empty table when backend unavailable, user only", async () => {
+        setupUserOnly();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/earthquakes/all").timeout();
+
+        const restoreConsole = mockConsole();
+
+        const { queryByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <EarthquakesIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+
+        const errorMessage = console.error.mock.calls[0][0];
+        expect(errorMessage).toMatch("Error communicating with backend via GET on /api/earthquakes/all");
+        restoreConsole();
+
+        expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
     });
 
 });
-
-


### PR DESCRIPTION
# Overview

just did the list page, everything looks fine, if you log in with admin, go to swagger UI and use retrieve to get the data from USGS, the list will then show up on earthquake - list, like this:
<img width="1432" alt="Screen Shot 2022-02-23 at 2 52 50 PM" src="https://user-images.githubusercontent.com/45847431/155423117-603b797d-1bc5-4b11-9887-f9335a97b10f.png">

# Issues Addressed

finished issue #26 

# Details

Where applicable, include "before" and "after" screenshots or animated GIFs.   The tool [LiceCAP](https://www.cockos.com/licecap/) or one of [these similar tools](https://www.nextofwindows.com/5-free-tools-to-screen-capture-to-gif-on-windows) 
can be used to capture screenshots/animated GIFs.

## Reminders (delete this section before merging or as code is merged)
- [ ] Explicitly link to this pull request each issue that it closes
- [ ] Assign one and ideally two reviewers to review this pull request. 
- [ ] Reviewers should not just approve with "Looks good!" Instead, reviewers should carefully go through the code and use GitHub's reviewer interface to ask questions, make comments, and suggest changes.
