### PR TITLE
rw - earthquakes list endpoint

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/EarthquakesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/EarthquakesController.java
@@ -50,8 +50,8 @@ public class EarthquakesController {
     }
 
     @PreAuthorize("hasRole('ROLE_USER')")
-    @ApiOperation(value = "List all earthquakes in the database", notes = "JSON return format documented here: https://earthquake.usgs.gov/earthquakes/feed/v1.0/geojson.php")
-    @PostMapping("/all")
+    @ApiOperation(value = "List all earthquakes in the database", notes = "Earthquakes must have been retreived from USGS by an admin first")
+    @GetMapping("/all")
     public Iterable<EarthquakeFeature> listEarthquakes() {
         log.info("list earthquakes");
 

--- a/src/main/java/edu/ucsb/cs156/example/controllers/EarthquakesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/EarthquakesController.java
@@ -49,6 +49,16 @@ public class EarthquakesController {
          return ResponseEntity.ok().body(savedResults);
     }
 
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @ApiOperation(value = "List all earthquakes in the database", notes = "JSON return format documented here: https://earthquake.usgs.gov/earthquakes/feed/v1.0/geojson.php")
+    @PostMapping("/all")
+    public Iterable<EarthquakeFeature> listEarthquakes() {
+        log.info("list earthquakes");
+
+        // get earthquakes from database
+        return earthquakesCollection.findAll();
+    }
+
     // not yet implemented, this was
 //    @PreAuthorize("hasRole('ROLE_USER')")
 //    @ApiOperation(value = "Get earthquakes a certain distance from UCSB's Storke Tower that are at or above a certain magnitude and add them to the database collection", notes = "JSON return format documented here: https://earthquake.usgs.gov/earthquakes/feed/v1.0/geojson.php")

--- a/src/test/java/edu/ucsb/cs156/example/controllers/EarthquakesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/EarthquakesControllerTests.java
@@ -142,4 +142,78 @@ public class EarthquakesControllerTests extends ControllerTestCase {
             .andExpect(status().is(403));
   }
 
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void api_earthquakes_all__user_logged_in__returns_all_earthquakes() throws Exception {
+    // create dummy Earthquake data
+    EarthquakeFeatureProperties props = EarthquakeFeatureProperties.builder()
+            .mag(5.6)
+            .place("testPlace")
+            .time(0x1000000000L)
+            .updated(0x1000000050L)
+            .tz(4)
+            .url("testPropertiesUrl")
+            .detail("testPropertiesDetail")
+            .felt(24)
+            .cdi(2.6)
+            .mmi(5.2)
+            .alert("testPropertiesAlert")
+            .status("testPropertiesStatus")
+            .tsunami(0)
+            .sig(114)
+            .net("testPropertiesNet")
+            .code("testPropertiesCode")
+            .ids("testPropertiesIds")
+            .sources("testPropertiesSources")
+            .types("testPropertiesTypes")
+            .nst(79)
+            .dmin(0.0207)
+            .rms(0.4)
+            .gap(65)
+            .magType("testPropertiesMagType")
+            .type("testPropertiesType")
+            .title("testPropertiesTitle")
+            .build();
+
+    EarthquakeFeatureGeometry geometry = EarthquakeFeatureGeometry.builder()
+            .type("Point")
+            .coordinates(List.of(0.0, 1.0, 2.0))
+            .id("testGeometryId")
+            .build();
+
+    EarthquakeFeature quake1 = EarthquakeFeature.builder()
+            ._id("")
+            .id("testQuakeId1")
+            .type("Feature")
+            .geometry(geometry)
+            .properties(props)
+            .build();
+
+    EarthquakeFeature quake2 = EarthquakeFeature.builder()
+            ._id("")
+            .id("testQuakeId2")
+            .type("Feature")
+            .geometry(geometry)
+            .properties(props)
+            .build();
+
+    List<EarthquakeFeature> quakeList = new ArrayList<>();
+    quakeList.add(quake1); quakeList.add(quake2);
+
+    when(earthquakesCollection.findAll()).thenReturn(quakeList);
+
+    MvcResult response = mockMvc.perform(get("/api/earthquakes/all"))
+            .andExpect(status().isOk()).andReturn();
+
+    verify(earthquakesCollection, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(quakeList);
+    String responseJson = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseJson);
+  }
+
+  @Test
+  public void api_earthquakes_all__logged_out__returns_403() throws Exception {
+    mockMvc.perform(get("/api/earthquakes/all")).andExpect(status().is(403));
+  }
+
 }


### PR DESCRIPTION
This pr addresses #23 by implementing a "/api/earthquakes/all" endpoint to list all items in our database to a logged in user:

<img width="1430" alt="image" src="https://user-images.githubusercontent.com/59625987/155409211-aac069ab-bec1-49a9-8f89-4c0e89f6f9a1.png">
