### PR TITLE
rw - implement earthquake API "purge" endpoint

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/EarthquakesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/EarthquakesController.java
@@ -59,12 +59,17 @@ public class EarthquakesController {
         return earthquakesCollection.findAll();
     }
 
-    // not yet implemented, this was
-//    @PreAuthorize("hasRole('ROLE_USER')")
-//    @ApiOperation(value = "Get earthquakes a certain distance from UCSB's Storke Tower that are at or above a certain magnitude and add them to the database collection", notes = "JSON return format documented here: https://earthquake.usgs.gov/earthquakes/feed/v1.0/geojson.php")
-//    @GetMapping("/all")
-//    public ResponseEntity<String> getEarthquakes() throws JsonProcessingException {
-//        return ResponseEntity.ok().body(result);
-//    }
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @ApiOperation(value = "Purges all earthquakes from MongoDB collection")
+    @PostMapping("/purge")
+    public ResponseEntity<String> purgeEarthquakes() throws JsonProcessingException {
+        log.info("purgeEarthquakes");
+
+        long numDeleted = earthquakesCollection.count();
+
+        earthquakesCollection.deleteAll();
+
+        return ResponseEntity.ok().body(String.format("%d earthquakes purged", numDeleted));
+    }
 
 }


### PR DESCRIPTION
This pr closes #22 by implementing the endpoint `/api/earthquakes/purge` to remove all earthquakes from the MongoDB collection:
<img width="1529" alt="image" src="https://user-images.githubusercontent.com/59625987/155417973-9261916d-54ff-41a5-b141-2544726c5fc9.png">
