### PR TITLE
fixed a potential problem we could have with ucsb subjects table 

### DIFF
--- a/frontend/src/main/components/UCSBSubjects/UCSBSubjectsTable.js
+++ b/frontend/src/main/components/UCSBSubjects/UCSBSubjectsTable.js
@@ -54,7 +54,8 @@ export default function UCSBSubjectsTable({ subjects, currentUser }) {
         },
         {
             Header: 'Inactive',
-            accessor: 'inactive',
+            accessor: row => String(row.inactive),
+            id: 'inactive',
         }
     ];
 


### PR DESCRIPTION
# Overview

https://ucsb-cs156-w22.slack.com/archives/C03392MKN0K/p1645415050723549
changed inactive from a boolean to a string when displaying it in the table 
